### PR TITLE
Fix #15: Ignore shim via comment

### DIFF
--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 // Prevent Karma from running prematurely.
 __karma__.loaded = function () {};
 

--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 // Prevent Karma from running prematurely.
 __karma__.loaded = function () {};
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,7 @@ webpackConfig.mode = 'development';
 webpackConfig.module.rules.push({
   test: /\.js$/,
   enforce: 'post',
-  exclude: [/\.spec.js$/, /node_modules/],
+  exclude: [/\.spec.js$/, /node_modules/, /karma-test-shim.js$/],
   loader: 'istanbul-instrumenter-loader',
   query: {
     esModules: true


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
Resolves #15 
## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
Added Istanbul comment to ignore file from coverage reports

More info:
https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines

Reports now only display the single component file.
![screen shot 2018-10-23 at 11 09 04 pm](https://user-images.githubusercontent.com/8385375/47403796-e66ead00-d718-11e8-8df5-d2a5f090763c.png)
