### PR TITLE
lint tasks as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,9 @@ jobs:
       - run:
           name: CEA Install Self Test
           command: node ./tasks/cea-install my-app
+
+      # this was part of the lint task but what was removed
+      # but have to be moved here since tasks/* wont be on the filesystem after an install
+      - run:
+          name: Self Lint of CEA Install Script
+          command: ./node_modules/.bin/eslint ./tasks/*.js

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "rimraf ./public && webpack --config ./webpack.config.prod.js --progress",
     "develop": "webpack-dev-server --config ./webpack.config.develop.js --open",
     "gh-pages": "rimraf ./docs && npm run build && cp -rv ./public/ ./docs",
-    "lint": "eslint *.js src/**/**/*.js tasks/*.js",
+    "lint": "eslint *.js src/**/**/*.js",
     "serve": "npm run build && ws",
     "start": "npm run develop",
     "test": "rimraf ./reports && karma start"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
resolves #28 `eslint` bug

## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
Fixes [bug reported with `eslint`](https://github.com/ProjectEvergreen/create-evergreen-app/issues/28#issuecomment-433644434) running as part of `yarn lint` but errors because [_tasks/*_ is not part of the install](https://github.com/ProjectEvergreen/create-evergreen-app/blob/master/tasks/cea-install.js#L7).