### PR TITLE
add ES2018 syntax support for CEA

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2017,
+    "ecmaVersion": 2018,
     "sourceType": "module"
   },
   "env": {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Resolves #36 

## Summary of Changes
1. Updated **ESLint** to support `es2018` support to allow [spread (`...`)](https://github.com/tc39/proposal-object-rest-spread) syntax

<img width="409" alt="screen shot 2018-10-31 at 6 06 17 pm" src="https://user-images.githubusercontent.com/895923/47821764-2dbbf580-dd38-11e8-8e8b-5361541e7322.png">