### PR TITLE
address inconsistent platform output of eslint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: thegreenhouse/nodejs-dev:0.2.0
+      - image: thegreenhouse/nodejs-dev:0.3.0
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
       - run:
           name: Install Project Dependencies
-          command: npm install
+          command: npm cache verfiy && npm install
 
       # tasks this was part of the lint npm task but was moved out
       # since tasks/* isn't part of the npx install and so lint would fail on the user's machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
       - run:
           name: Install Project Dependencies
-          command: npm cache verfiy && npm install
+          command: npm cache verify && npm install
 
       # tasks this was part of the lint npm task but was moved out
       # since tasks/* isn't part of the npx install and so lint would fail on the user's machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       # since tasks/* isn't part of the npx install and so lint would fail on the user's machine
       - run:
           name: Run Linter
-          command: npm run lint && ./node_modules/.bin/eslint \"./tasks/*.js\"
+          command: npm run lint && ./node_modules/.bin/eslint "./tasks/*.js"
 
       - run:
           name: Run Unit Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,11 @@ jobs:
           name: Install Project Dependencies
           command: npm install
 
+      # tasks this was part of the lint npm task but was moved out
+      # since tasks/* isn't part of the npx install and so lint would fail on the user's machine
       - run:
           name: Run Linter
-          command: npm run lint
+          command: npm run lint && ./node_modules/.bin/eslint \"./tasks/*.js\"
 
       - run:
           name: Run Unit Tests
@@ -39,12 +41,6 @@ jobs:
       - run:
           name: CEA Install Self Test
           command: node ./tasks/cea-install my-app
-
-      # this was part of the lint npm task
-      # but have to be moved here since tasks/* wont be on the filesystem after an npx install
-      - run:
-          name: Lint CEA Scripts
-          command: ./node_modules/.bin/eslint \"./tasks/*.js\"
 
       # Sanity test yarn install and tasks
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,11 @@ jobs:
           name: CEA Install Self Test
           command: node ./tasks/cea-install my-app
 
-      # this was part of the lint task but what was removed
-      # but have to be moved here since tasks/* wont be on the filesystem after an install
+      # this was part of the lint npm task
+      # but have to be moved here since tasks/* wont be on the filesystem after an npx install
       - run:
-          name: Self Lint of CEA Install Script
-          command: ./node_modules/.bin/eslint ./tasks/*.js
+          name: Lint CEA Scripts
+          command: ./node_modules/.bin/eslint \"./tasks/*.js\"
 
       # Sanity test yarn install and tasks
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: thegreenhouse/nodejs-dev:0.3.0
+      - image: thegreenhouse/nodejs-dev:0.2.0
 
     working_directory: ~/repo
 
@@ -10,11 +10,11 @@ jobs:
       - checkout
 
       # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+      # - restore_cache:
+      #     keys:
+      #     - v1-dependencies-{{ checksum "package.json" }}
+      #     # fallback to using the latest cache if no exact match is found
+      #     - v1-dependencies-
 
       - run:
           name: Debug environment
@@ -22,7 +22,7 @@ jobs:
 
       - run:
           name: Install Project Dependencies
-          command: npm cache verify && npm install
+          command: npm install
 
       # tasks this was part of the lint npm task but was moved out
       # since tasks/* isn't part of the npx install and so lint would fail on the user's machine

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "rimraf ./public && webpack --config ./webpack.config.prod.js --progress",
     "develop": "webpack-dev-server --config ./webpack.config.develop.js --open",
     "gh-pages": "rimraf ./docs && npm run build && cp -rv ./public/ ./docs",
-    "lint": "eslint *.js src/**/**/*.js",
+    "lint": "eslint \"*.js\" \"./src/**/*.js\"",
     "serve": "npm run build && ws",
     "start": "npm run develop",
     "test": "rimraf ./reports && karma start"

--- a/tasks/cea-install.js
+++ b/tasks/cea-install.js
@@ -27,4 +27,4 @@ console.log(`Just run: cd ${TARGET_DIR}`);
 console.log('And then: npm install && npm start (or use yarn)');
 console.log('-------------------------------------------------------');
 
-process.exit(); // eslint-disable-line no-process-exit
+process.exit();

--- a/tasks/cea-install.js
+++ b/tasks/cea-install.js
@@ -27,4 +27,4 @@ console.log(`Just run: cd ${TARGET_DIR}`);
 console.log('And then: npm install && npm start (or use yarn)');
 console.log('-------------------------------------------------------');
 
-process.exit();
+process.exit(); // eslint-disable-line no-process-exit


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #49 

## Summary of Changes
1. Use escaped double quotes when running eslint via the CLI in _package.json_ and CircleCI