### PR TITLE
add D flag to npx, add lock files to project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Immediate needs for this repo are:
 Make sure you have a LTS version of [Node.js installed](https://nodejs.org/) and then follow these steps to get up and running:
 ```shell
 # 1) Create new evergreen app
-$ npx create-evergreen-app my-app
+$ npx -D create-evergreen-app my-app
 
 # 2) Change Directory
 $ cd my-app

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ $ npm start
 $ yarn start
 ```
 
+You can also clone the repo from GitHub
+```shell
+$ git clone https://github.com/ProjectEvergreen/create-evergreen-app.git my-app
+$ cd my-app && npm install # or yarn install
+$ npm start # or yarn start
+```
+
 > 📖 For more documentation and developer guides that cover topics like the build process, browser and device support, creating components, and more, please check out our [wiki](https://github.com/ProjectEvergreen/create-evergreen-app/wiki)!
 
 ## Usage

--- a/tasks/cea-clean.js
+++ b/tasks/cea-clean.js
@@ -1,8 +1,0 @@
-#!/usr/bin/env node
-// helpful just for cleanup up a CEA install while testing the release process
-const cp = require('child_process');
-const CLEANUP_DIRS = ['docs', '.circleci', '.github', '.git', '.npmignore', 'tasks'];
-
-CLEANUP_DIRS.forEach((directory) => {
-  cp.execSync(`rm -rf ${directory}`);
-});

--- a/tasks/cea-install.js
+++ b/tasks/cea-install.js
@@ -77,6 +77,8 @@ const srcInit = async () => {
     '.editorconfig',
     '.eslintrc',
     '.gitignore',
+    'yarn.lock',
+    'package-lock.json',
     'babel.config.js',
     'karma-test-shim.js',
     'karma.conf.js',

--- a/tasks/cea-install.js
+++ b/tasks/cea-install.js
@@ -78,6 +78,7 @@ const srcInit = async () => {
     '.editorconfig',
     '.eslintrc',
     '.gitignore',
+    '.gitattributes',
     'yarn.lock',
     'package-lock.json',
     'babel.config.js',

--- a/tasks/cea-install.js
+++ b/tasks/cea-install.js
@@ -74,6 +74,7 @@ const npmInit = async () => {
 const srcInit = async () => {
   const copyDirs = [
     'src',
+    '.browserslistrc',
     '.editorconfig',
     '.eslintrc',
     '.gitignore',


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #54 and #55 

## Summary of Changes
1. Update README install steps to pass `-D` flag when running `npx` to get `devDependencies` installed
1. Added `lock` files when setting up the new project workspace
1. Added `.browserslistrc` when setting up the new project workspace
1. Added `.gitattributes` when setting up the new project workspace
1. Removed unneeded tasks file


Going to try and test against this branch locally using `npx`