### PR TITLE
Add Docker Support, closes #68

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Modified Brett Fisher's node-docker-good-defaults https://github.com/BretFisher/node-docker-good-defaults/blob/master/Dockerfile
+FROM node:10
+
+# set our node environment, either development or production
+# defaults to production, compose overrides this to development on build and run
+ARG NODE_ENV=production
+ENV NODE_ENV $NODE_ENV
+
+# default to port 8000 for node, and 9229 and 9230 (tests) for debug
+ARG PORT=8000
+ENV PORT $PORT
+EXPOSE $PORT 9229 9230
+
+RUN npm i npm@latest -g
+
+# install dependencies first, in a different location for easier app bind mounting for local development
+WORKDIR /opt
+COPY package.json package-lock.json* ./
+RUN npm install && \
+    npm install --only=dev && \
+    npm cache clean --force
+ENV PATH /opt/node_modules/.bin:$PATH
+
+WORKDIR /opt/app
+COPY . /opt/app
+RUN echo "node_modules" > .eslintignore
+
+# the official node image provides an unprivileged user as a security best practice
+# https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
+RUN chown -R node /opt/app
+USER node
+
+RUN npm run build
+
+# use `docker run --init in production`
+# so that signals are passed properly.
+CMD [ "ws" ]

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     ".editorconfig",
     ".eslintrc",
     ".gitattributes",
+    "Dockerfile",
     "yarn.lock",
     "package-lock.json",
     "babel.config.js",


### PR DESCRIPTION
## Related Issue
closes #68 

## Summary of Changes

Added a Dockerfile and updated the package.json to include that file.

Dockerfile will:

1. Built from node:10
2. Set environment to production
3. Expose ws port 8000 and test ports
4. Install latest npm
5. copy package.json to /opt and install it
6. set node_modules to path
7. Copy source code to /opt/app
8. Create .eslintignore to ignore node_modules
9. Set permissions so that the ./public folder is created and removed correctly on build 
10. Run as a non-root user
11. Build
12. Run local web server
